### PR TITLE
Updated containsFields utility function

### DIFF
--- a/sdk-test/src/main/kotlin/io/datalbry/connector/sdk/test/TestingTypeUtil.kt
+++ b/sdk-test/src/main/kotlin/io/datalbry/connector/sdk/test/TestingTypeUtil.kt
@@ -13,7 +13,7 @@ inline fun <reified Type> Record.isOfType() = Type::class.simpleName == this.typ
 /**
  * Checks if a document contains all given fields
  */
-fun <T> Record.containsFields(fields: Collection<Field<T>>): Boolean {
+fun Record.containsFields(fields: Collection<Field<*>>): Boolean {
     return this.fields.containsAll(fields);
 }
 


### PR DESCRIPTION
Changed the signature of the extension function to work with mixed generic types of `Field<>`.

Example use case:

```kotlin

var document = ... // some generic document
var expectedFields = listOf(
    GenericField(name = "id", value = 1), // GenericField<Int>
    GenericField(name = "name", value = "name"), // GenericField<String>
)
assertTrue(document.contiansFields(expectedFields))
```

with the current version of the function `containsFields` this is not possible. The compiler will error out with a Type mismatch in this case. When the change is applied to the signature this works as expected. 


