### PR TITLE
feat: Can now serialize maps to records too

### DIFF
--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
@@ -44,11 +44,17 @@ class AnyToRecordMapper {
 
         return basicFields.toSet() + complexFields
             .map {
-                when(val value = it.value) {
+                when (val value = it.value) {
                     is Array<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
                     is Collection<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
+                    is RecordMap -> GenericField(it.name, (it.value as RecordMap).toGenericRecord())
                     else -> GenericField(it.name, getRecord(value))
                 }
             }
     }
+
+    private fun RecordMap.toGenericRecord() = GenericRecord(
+        type = this.recordName,
+        fields = this.map { (k, v) -> GenericField(k, v) }.toSet()
+    )
 }

--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/RecordMap.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/RecordMap.kt
@@ -1,0 +1,3 @@
+package io.datalbry.connector.sdk.consumer.generic
+
+class RecordMap(val recordName: String) : HashMap<String, Any>()

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
@@ -2,6 +2,8 @@ package io.datalbry.connector.sdk.consumer.generic
 
 import io.datalbry.connector.sdk.consumer.generic.documents.*
 import io.datalbry.precise.api.schema.document.Record
+import io.datalbry.precise.api.schema.document.generic.GenericField
+import io.datalbry.precise.api.schema.document.generic.GenericRecord
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -131,6 +133,29 @@ internal class GenericItemMapperTest {
         val children = mapper.getEdges(container)
         val sourceEdges = childrenInput.map(Child::toEdge)
         assertTrue(children.containsAll(sourceEdges))
+    }
+
+
+    @Test
+    fun getDocuments_map_serializingMapToRecordCorrectly() {
+        val values = RecordMap("CsvRowType")
+        values.putAll(mapOf<String, Any>("hello" to "world", "1" to 1))
+        val item = DocumentWithMap(
+            docId="documentId",
+            title="Collection Item",
+            values= values,
+            modified=ZonedDateTime.now().toString()
+        )
+        val mapper = GenericItemMapper(item::class)
+        val documents = mapper.getDocuments(item)
+        assertTrue(documents.isNotEmpty())
+        val document = documents.first()
+        val mapRecord = document[DocumentWithMap::values.name]
+
+        with(mapRecord.value as GenericRecord) {
+            assertEquals(values.recordName, this.type)
+            values.forEach { (key, value) -> assertEquals(value, this[key].value) }
+        }
     }
 }
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithMap.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithMap.kt
@@ -1,0 +1,14 @@
+package io.datalbry.connector.sdk.consumer.generic.documents
+
+import io.datalbry.connector.api.annotation.property.Checksum
+import io.datalbry.connector.api.annotation.property.Id
+import io.datalbry.connector.api.annotation.stereotype.Document
+import io.datalbry.connector.sdk.consumer.generic.RecordMap
+
+@Document
+data class DocumentWithMap(
+    @Id val docId: String,
+    val title: String,
+    val values: RecordMap,
+    @Checksum val modified: String,
+)


### PR DESCRIPTION
We needed some kind of capability to serialize data structures which are
not known during compile time (e.g. CSV schema). This can be solved by
making use of maps. Before the connector SDK couldn't handle them. Now
there has been introduced a way to handle them with a custom map class.

Ref: #30