### PR TITLE
fix/issue 38/serialise optional complex property

### DIFF
--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
@@ -1,12 +1,14 @@
 package io.datalbry.connector.sdk.consumer.generic
 
-import io.datalbry.connector.sdk.util.annotatedWith
+import io.datalbry.connector.sdk.extension.annotatedWith
+import io.datalbry.connector.sdk.extension.isOptionalWithGenericType
 import io.datalbry.connector.sdk.util.isBasicFieldType
 import io.datalbry.precise.api.schema.Exclude
 import io.datalbry.precise.api.schema.document.Field
 import io.datalbry.precise.api.schema.document.Record
 import io.datalbry.precise.api.schema.document.generic.GenericField
 import io.datalbry.precise.api.schema.document.generic.GenericRecord
+import java.util.*
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.javaGetter
 
@@ -34,7 +36,7 @@ class AnyToRecordMapper {
     }
 
     private fun getMetadata(item: Any): Set<Field<*>> {
-        val getter = item::class.declaredMemberProperties
+        val getter = item::class.declaredMemberProperties.toList()
         val (basicFields, complexFields) = getter
             .asSequence()
             .filterNot { it.annotatedWith<Exclude>() }
@@ -47,6 +49,7 @@ class AnyToRecordMapper {
                 when(val value = it.value) {
                     is Array<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
                     is Collection<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
+                    is Optional<*> -> GenericField(it.name, value.map(this::getRecord))
                     else -> GenericField(it.name, getRecord(value))
                 }
             }

--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
@@ -45,11 +45,12 @@ class AnyToRecordMapper {
 
         return basicFields.toSet() + complexFields
             .map {
-                when(val value = it.value) {
+                when (val value = it.value) {
                     is Array<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
                     is Collection<*> -> GenericField(it.name, value.filterNotNull().map(this::getRecord))
                     is Optional<*> -> GenericField(it.name, value.map(this::getRecord))
-                    else -> GenericField(it.name, getRecord(value))
+                    else -> GenericField(it.name, if (value != null) getRecord(value) else null)
+
                 }
             }
     }

--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/AnyToRecordMapper.kt
@@ -1,7 +1,6 @@
 package io.datalbry.connector.sdk.consumer.generic
 
 import io.datalbry.connector.sdk.extension.annotatedWith
-import io.datalbry.connector.sdk.extension.isOptionalWithGenericType
 import io.datalbry.connector.sdk.util.isBasicFieldType
 import io.datalbry.precise.api.schema.Exclude
 import io.datalbry.precise.api.schema.document.Field

--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapper.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapper.kt
@@ -6,7 +6,7 @@ import io.datalbry.connector.api.DocumentEdge
 import io.datalbry.connector.api.annotation.property.Checksum
 import io.datalbry.connector.sdk.consumer.AdditionMessageConsumer.Companion.CHECKSUM_FIELD
 import io.datalbry.connector.sdk.consumer.generic.GenericCrawlProcessor.Companion.TYPE_KEY
-import io.datalbry.connector.sdk.util.annotatedWith
+import io.datalbry.connector.sdk.extension.annotatedWith
 import io.datalbry.precise.api.schema.document.Document
 import io.datalbry.precise.api.schema.document.Field
 import io.datalbry.precise.api.schema.document.generic.GenericDocument

--- a/sdk/src/main/kotlin/io/datalbry/connector/sdk/extension/KProperty1Extensions.kt
+++ b/sdk/src/main/kotlin/io/datalbry/connector/sdk/extension/KProperty1Extensions.kt
@@ -1,4 +1,4 @@
-package io.datalbry.connector.sdk.util
+package io.datalbry.connector.sdk.extension
 
 import kotlin.reflect.KProperty1
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
@@ -147,8 +147,46 @@ internal class GenericItemMapperTest {
     }
 
     @Test
+    fun getDocument_mappingOptionalEmptySimpleProperty_correctlyMapped() {
+        val item = DocumentWithOptionalSimpleProperty(
+            1,
+            Optional.empty(),
+            Optional.empty(),
+            TestRecordWithOptionalSimpleProperty(
+                1,
+                Optional.of("TestString"),
+                Optional.of(1),
+            )
+        )
+        val mapper = GenericItemMapper(DocumentWithOptionalSimpleProperty::class)
+        val document = mapper.getDocuments(item).first()
+        val expected = GenericDocument(
+            type = "DocumentWithOptionalSimpleProperty",
+            id = UUID.nameUUIDFromBytes(item.id.toString().toByteArray()).toString(),
+            fields = setOf(
+                GenericField("id", 1),
+                GenericField("optionalInt", Optional.empty<Int>()),
+                GenericField("optionalString", Optional.empty<String>()),
+                GenericField(
+                    "testRecordWithOptionalSimpleProperty",
+                    GenericRecord(
+                        type = "TestRecordWithOptionalSimpleProperty",
+                        setOf(
+                            GenericField("id", 1),
+                            GenericField("optionalInt", Optional.of(1)),
+                            GenericField("optionalString", Optional.of("TestString")),
+                        )
+                    )
+                ),
+                GenericField("_checksum", "")
+            )
+        )
+        assertEquals(expected, document)
+    }
+
+    @Test
     fun getDocument_mappingOptionalEmptyComplexProperty_correctlyMapped() {
-        val item = DocumentWithOptionalComplexProperty(1, Optional.empty())
+        val item = DocumentWithOptionalComplexProperty(1, Optional.empty(), Optional.empty(), Optional.empty())
         val mapper = GenericItemMapper(DocumentWithOptionalComplexProperty::class)
         val document = mapper.getDocuments(item).first()
         val expected = GenericDocument(
@@ -156,6 +194,8 @@ internal class GenericItemMapperTest {
             id = UUID.nameUUIDFromBytes(item.id.toString().toByteArray()).toString(),
             fields = setOf(
                 GenericField("id", 1),
+                GenericField("optionalInt", Optional.empty<Int>()),
+                GenericField("optionalString", Optional.empty<String>()),
                 GenericField(
                     "testRecordWithOptionalRecord",
                     Optional.empty<TestRecordWithOptionalRecord>()
@@ -170,9 +210,12 @@ internal class GenericItemMapperTest {
     fun getDocument_mappingOptionalComplexProperty_correctlyMapped() {
         val item = DocumentWithOptionalComplexProperty(
             1,
+            Optional.of("TestString"),
+            Optional.of(1),
             Optional.of(
                 TestRecordWithOptionalRecord(
-                    1, Optional.empty()
+                    1,
+                    Optional.empty()
                 )
             )
         )
@@ -183,6 +226,8 @@ internal class GenericItemMapperTest {
             id = UUID.nameUUIDFromBytes(item.id.toString().toByteArray()).toString(),
             fields = setOf(
                 GenericField("id", 1),
+                GenericField("optionalInt", Optional.of(1)),
+                GenericField("optionalString", Optional.of("TestString")),
                 GenericField(
                     "testRecordWithOptionalRecord",
                     Optional.of(

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
@@ -2,6 +2,9 @@ package io.datalbry.connector.sdk.consumer.generic
 
 import io.datalbry.connector.sdk.consumer.generic.documents.*
 import io.datalbry.precise.api.schema.document.Record
+import io.datalbry.precise.api.schema.document.generic.GenericDocument
+import io.datalbry.precise.api.schema.document.generic.GenericField
+import io.datalbry.precise.api.schema.document.generic.GenericRecord
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -144,6 +147,26 @@ internal class GenericItemMapperTest {
     }
 
     @Test
+    fun getDocument_mappingOptionalEmptyComplexProperty_correctlyMapped() {
+        val item = DocumentWithOptionalComplexProperty(1, Optional.empty())
+        val mapper = GenericItemMapper(DocumentWithOptionalComplexProperty::class)
+        val document = mapper.getDocuments(item).first()
+        val expected = GenericDocument(
+            type = "DocumentWithOptionalComplexProperty",
+            id = UUID.nameUUIDFromBytes(item.id.toString().toByteArray()).toString(),
+            fields = setOf(
+                GenericField("id", 1),
+                GenericField(
+                    "testRecordWithOptionalRecord",
+                    Optional.empty<TestRecordWithOptionalRecord>()
+                ),
+                GenericField("_checksum", "")
+            )
+        )
+        assertEquals(expected, document)
+    }
+
+    @Test
     fun getDocument_mappingOptionalComplexProperty_correctlyMapped() {
         val item = DocumentWithOptionalComplexProperty(
             1,
@@ -154,10 +177,28 @@ internal class GenericItemMapperTest {
             )
         )
         val mapper = GenericItemMapper(DocumentWithOptionalComplexProperty::class)
-
-        assertDoesNotThrow {
-            val documents = mapper.getDocuments(item)
-        }
+        val document = mapper.getDocuments(item).first()
+        val expected = GenericDocument(
+            type = "DocumentWithOptionalComplexProperty",
+            id = UUID.nameUUIDFromBytes(item.id.toString().toByteArray()).toString(),
+            fields = setOf(
+                GenericField("id", 1),
+                GenericField(
+                    "testRecordWithOptionalRecord",
+                    Optional.of(
+                        GenericRecord(
+                            "TestRecordWithOptionalRecord",
+                            setOf(
+                                GenericField("id", 1),
+                                GenericField("testRecord", Optional.empty<TestRecord>()),
+                            )
+                        )
+                    )
+                ),
+                GenericField("_checksum", "")
+            )
+        )
+        assertEquals(expected, document)
     }
 }
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
@@ -245,5 +245,22 @@ internal class GenericItemMapperTest {
         )
         assertEquals(expected, document)
     }
+
+    @Test
+    fun getDocument_mappingNullableSimpleProperty_correctlyMapped() {
+        val item = DocumentWithNullableSimpleProperty(
+            1,
+            null,
+            null,
+            TestRecordWithNullableSimpleProperty(
+                1,
+                null,
+                null
+            )
+        )
+        val mapper = GenericItemMapper(DocumentWithNullableSimpleProperty::class)
+        val document = mapper.getDocuments(item).first()
+        println("")
+    }
 }
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/GenericItemMapperTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.assertThrows
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.*
-import kotlin.NoSuchElementException
 
 internal class GenericItemMapperTest {
 
@@ -55,7 +54,8 @@ internal class GenericItemMapperTest {
 
     @Test
     fun getDocuments_documentContainsCollection_workJustFine() {
-        val item = DocumentWithCollection("another unique id", "Collection Item", listOf(""), ZonedDateTime.now().toString())
+        val item =
+            DocumentWithCollection("another unique id", "Collection Item", listOf(""), ZonedDateTime.now().toString())
         val mapper = GenericItemMapper(item::class)
 
         val document = mapper.getDocuments(item).first()
@@ -69,7 +69,12 @@ internal class GenericItemMapperTest {
 
     @Test
     fun getDocuments_containingCollectionOfIds_gettingReducedCorrectly() {
-        val item = DocumentWithIdCollection(listOf("id1", "id2"), "Collection Item", listOf(""), ZonedDateTime.now().toString())
+        val item = DocumentWithIdCollection(
+            listOf("id1", "id2"),
+            "Collection Item",
+            listOf(""),
+            ZonedDateTime.now().toString()
+        )
         val mapper = GenericItemMapper(item::class)
 
         val document = mapper.getDocuments(item).first()
@@ -101,7 +106,12 @@ internal class GenericItemMapperTest {
 
     @Test
     fun getDocuments_deconstructingComplexFields_areMappedToRecords() {
-        val item = DocumentWithComplexProperty("id", "Collection Item", Person("test", "test@example.org") ,ZonedDateTime.now().toString())
+        val item = DocumentWithComplexProperty(
+            "id",
+            "Collection Item",
+            Person("test", "test@example.org"),
+            ZonedDateTime.now().toString()
+        )
         val mapper = GenericItemMapper(item::class)
 
         val document = mapper.getDocuments(item).first()
@@ -131,6 +141,23 @@ internal class GenericItemMapperTest {
         val children = mapper.getEdges(container)
         val sourceEdges = childrenInput.map(Child::toEdge)
         assertTrue(children.containsAll(sourceEdges))
+    }
+
+    @Test
+    fun getDocument_mappingOptionalComplexProperty_correctlyMapped() {
+        val item = DocumentWithOptionalComplexProperty(
+            1,
+            Optional.of(
+                TestRecordWithOptionalRecord(
+                    1, Optional.empty()
+                )
+            )
+        )
+        val mapper = GenericItemMapper(DocumentWithOptionalComplexProperty::class)
+
+        assertDoesNotThrow {
+            val documents = mapper.getDocuments(item)
+        }
     }
 }
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithNullableSimpleProperty.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithNullableSimpleProperty.kt
@@ -1,0 +1,25 @@
+package io.datalbry.connector.sdk.consumer.generic.documents
+
+import io.datalbry.connector.api.annotation.property.Id
+import io.datalbry.connector.api.annotation.stereotype.Document
+import io.datalbry.precise.api.schema.Nullable
+import io.datalbry.precise.api.schema.SchemaAware
+import java.util.*
+
+@Document
+@SchemaAware
+data class DocumentWithNullableSimpleProperty(
+    @Id val id: Int,
+    @Nullable val optionalString: String?,
+    @Nullable val optionalInt: Int?,
+    @Nullable val testRecordWithNullableSimpleProperty: TestRecordWithNullableSimpleProperty?
+)
+
+
+@SchemaAware
+data class TestRecordWithNullableSimpleProperty(
+    val id: Int,
+    @Nullable val optionalString: String?,
+    @Nullable val optionalInt: Int?,
+)
+

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalComplexProperty.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalComplexProperty.kt
@@ -1,0 +1,19 @@
+package io.datalbry.connector.sdk.consumer.generic.documents
+
+import io.datalbry.connector.api.annotation.stereotype.Document
+import io.datalbry.precise.api.schema.SchemaAware
+import java.util.*
+
+@Document
+@SchemaAware
+data class DocumentWithOptionalComplexProperty(
+    val id: Int,
+    val testRecordWithOptionalRecord: Optional<TestRecordWithOptionalRecord>
+)
+
+
+@SchemaAware
+data class TestRecordWithOptionalRecord(val id: Int, val testRecord: Optional<TestRecord>)
+
+@SchemaAware
+data class TestRecord(val a: Int)

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalComplexProperty.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalComplexProperty.kt
@@ -1,5 +1,6 @@
 package io.datalbry.connector.sdk.consumer.generic.documents
 
+import io.datalbry.connector.api.annotation.property.Id
 import io.datalbry.connector.api.annotation.stereotype.Document
 import io.datalbry.precise.api.schema.SchemaAware
 import java.util.*
@@ -7,7 +8,7 @@ import java.util.*
 @Document
 @SchemaAware
 data class DocumentWithOptionalComplexProperty(
-    val id: Int,
+    @Id val id: Int,
     val testRecordWithOptionalRecord: Optional<TestRecordWithOptionalRecord>
 )
 

--- a/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalSimpleProperty.kt
+++ b/sdk/src/test/kotlin/io/datalbry/connector/sdk/consumer/generic/documents/DocumentWithOptionalSimpleProperty.kt
@@ -7,21 +7,18 @@ import java.util.*
 
 @Document
 @SchemaAware
-data class DocumentWithOptionalComplexProperty(
+data class DocumentWithOptionalSimpleProperty(
     @Id val id: Int,
     val optionalString: Optional<String>,
     val optionalInt: Optional<Int>,
-    val testRecordWithOptionalRecord: Optional<TestRecordWithOptionalRecord>
+    val testRecordWithOptionalSimpleProperty: TestRecordWithOptionalSimpleProperty
 )
 
 
 @SchemaAware
-data class TestRecordWithOptionalRecord(
+data class TestRecordWithOptionalSimpleProperty(
     val id: Int,
-    val testRecord: Optional<TestRecord>
-    )
-
-@SchemaAware
-data class TestRecord(
-    val a: Int
+    val optionalString: Optional<String>,
+    val optionalInt: Optional<Int>,
 )
+


### PR DESCRIPTION
This branch implements correct serialisation of Optionals of complex properties.

Related Issue: https://github.com/datalbry/connector-sdk/issues/38